### PR TITLE
[Refactor] l_1.py 使用者類加入allow_deactivate方法，符合里氏替換原則

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ O : 封閉修改，開放擴充原則 Open-Closed Principle
 
 L : 里氏替換原則 Liskov Substitution Principle
 
-    - 搭配例子 - TBC 
+    - 搭配例子 - [以User及Admin的停用操作，列出相關貼文兩個功能舉例] 
 
 I : 接口隔離原則 Interface Segregation Principles
 

--- a/d.py
+++ b/d.py
@@ -1,0 +1,59 @@
+'''
+`SiteSourceGrouper`依賴於 `requests`, `lxml`
+假想情境為 : 寫測試時，local端可以訪問外網，但是server端不行，縱使可以使用mock
+但這裡希望將是否為local端還是server端與計算域名統計解耦合
+
+Dependency Inversion Principle : 高階模組與低階模組不應該互相依賴，兩者應該依賴於抽象層
+使用Dependency Inversion Principle
+設計的好處，若需求頻繁變動在低階模組，很多新增項目，就能夠透過中基層一次收集起來，然後執行
+
+典型的例子就是sklearn的Pipeline物件
+或是自己寫的transformer抽象物件，裡面可以裝preprocessing function
+'''
+import requests
+from lxml import etree
+from typing import Dict
+from collections import Counter
+
+
+class SiteSourceGrouper:
+    """
+    對HackerNews的域名進行分組統計
+    """
+
+    def __init__(self, url: str):
+        self.url = url
+
+    def get_groups(self) -> Dict[str, int]:
+        """
+        獲取域名、個數資料
+        """
+        resp = requests.get(self.url)
+        html = etree.HTML(resp.text)
+        elems = html.xpath(
+            '//table[@class="itemlist"]//span[@class="sitestr"]')
+
+        groups = Counter()
+        for elem in elems:
+            groups.update([elem.text])
+        return groups
+
+
+def test_grouper_returning_valid_types():
+    """测试 get_groups 是否返回了正确类型
+    """
+    grouper = SiteSourceGrouper('https://news.ycombinator.com/')
+    result = grouper.get_groups()
+    assert isinstance(result, Counter), "groups should be Counter instance"
+
+
+def main():
+    groups = SiteSourceGrouper("https://news.ycombinator.com/").get_groups()
+    for key, value in groups.most_common(3):
+        print(f'Site: {key} | Count: {value}')
+    test_grouper_returning_valid_types()
+    print('Test passed!')
+
+
+if __name__ == '__main__':
+    main()

--- a/i.py
+++ b/i.py
@@ -1,0 +1,15 @@
+'''
+接口隔離原則(Interface Segregation Principle)
+使用者/客戶若只使用到A功能，那麼類別就不要給A功能以外的方法
+
+
+不這麼設計的壞處 : 以避免未來繼承時、擴充時接口可能出現無法預期的bug，或是子類無法完全取代父類的行為
+使用街口隔離原則設計的好處 : 未來在擴充時，子類容易完全取代父類行為，小的接口不容易出現無法預期的bug
+'''
+
+
+def is_new_visitor(response) -> bool:
+    """
+    從cookie判斷是否是新的訪客
+    """
+    return response.cookies.get('is_new_visitor') == 'y'

--- a/i.py
+++ b/i.py
@@ -8,8 +8,8 @@
 '''
 
 
-def is_new_visitor(response) -> bool:
+def is_new_visitor(cookies) -> bool:
     """
     從cookie判斷是否是新的訪客
     """
-    return response.cookies.get('is_new_visitor') == 'y'
+    return cookies.get('is_new_visitor') == 'y'

--- a/l_1.py
+++ b/l_1.py
@@ -46,6 +46,12 @@ class Admin(User):
         """
         return False
 
+    def deactivate(self):
+        """
+        停用該使用者，但Admin不能被停用
+        """
+        raise NotImplementedError('Cannot deactivate Admin')
+
 
 def deactivate_users(users: Iterable[User]):
     """
@@ -55,10 +61,10 @@ def deactivate_users(users: Iterable[User]):
         # 該使用者無法被停用
         if not user.allow_deactivate():
             print(
-                f'''skip deactivating user {user.username}\n because it is {user.__class__.__name__}''')
+                f'skip deactivating user {user.username}\n because it is {user.__class__.__name__}')
             continue
         else:
-            user.deactivate
+            user.deactivate()
 
 
 def main():

--- a/l_1.py
+++ b/l_1.py
@@ -6,6 +6,10 @@
 那麼維護成本就會提高，可讀性也降低
 以下舉例為
 普通使用者User及管理員Admin對於停用方法`deactivate`的設計方式所需付出的維護成本
+
+若未來加入了Staff類別，VIP類別等，對於停用方法可能又有不同的要求，屆時維護成本提高
+以下透過理事替換原則進行設計，設計邏輯為 子類應當可以把父類全部換掉，程式還是能跑
+以下設計使得未來需求就算擴充到Staff, VIP, deactivate_users也不用重寫，可讀性也較好 
 '''
 from typing import Iterable
 
@@ -17,6 +21,12 @@ class User():
 
     def __init__(self, username: str):
         self.username = username
+
+    def allow_deactivate(self) -> bool:
+        """
+        是否允許停用
+        """
+        return True
 
     def deactivate(self):
         """
@@ -30,13 +40,11 @@ class Admin(User):
     管理員
     """
 
-    def deactivate(self):
+    def allow_deactivate(self) -> bool:
         """
-        管理員無法被停用
-        Raises:
-            RuntimeError: [管理員無法被停用]
+        是否允許停用
         """
-        raise RuntimeError('admin can not be deactivated!')
+        return False
 
 
 def deactivate_users(users: Iterable[User]):
@@ -44,12 +52,13 @@ def deactivate_users(users: Iterable[User]):
     批量停用使用者
     """
     for user in users:
-        # 無法停用管理員，跳過
-        if isinstance(user, Admin):
-            print(f'skip deactivating admin user {user.username}')
+        # 該使用者無法被停用
+        if not user.allow_deactivate():
+            print(
+                f'''skip deactivating user {user.username}\n because it is {user.__class__.__name__}''')
             continue
         else:
-            user.deactivate()
+            user.deactivate
 
 
 def main():

--- a/o.py
+++ b/o.py
@@ -1,6 +1,6 @@
 import os
 import pickle
-from typing import Tuple, Callable
+from typing import Tuple
 import matplotlib.pyplot as plt
 from matplotlib.axes._subplots import Axes
 import re
@@ -86,7 +86,18 @@ def plot_history(history: dict,
     return ax1, ax2
 
 
-def main(extract_lbl_keyword_func: Callable):
+def extract_label_keyword_func(exp_name: str, extract_pattern: re.Pattern) -> str:
+    """
+    Args:
+        exp_name (str): 輸入的實驗名稱
+        extract_pattern(re.Pattern) : 擷取標籤的正則表達式
+    Returns:
+        str: 輸出的histroy plot label
+    """
+    return extract_pattern.search(exp_name).group()
+
+
+def main(pattern_to_extract_label: re.Pattern):
     display_exp = sorted(os.listdir('experiments'))
     exp_s = "\n".join(display_exp)
     print(f'all experiments are : {exp_s}')
@@ -118,7 +129,8 @@ def main(extract_lbl_keyword_func: Callable):
                     row = 2
                 else:
                     raise ValueError('should be 3 fold in this experiments')
-                short_exp_name = extract_lbl_keyword_func(exp_name)
+                short_exp_name = extract_label_keyword_func(exp_name,
+                                                            pattern_to_extract_label)
                 axes[row][0], axes[row][1] = plot_history(history=history,
                                                           ax1=axes[row][0], ax2=axes[row][1],
                                                           lbl=short_exp_name,
@@ -136,17 +148,5 @@ def main(extract_lbl_keyword_func: Callable):
 
 
 if __name__ == "__main__":
-    def extract_lbl_keyword_func(exp_name: str) -> str:
-        """
-        擷取實驗名稱，放在畫圖的legend上
-
-        Args:
-            exp_name (str): 輸入的實驗名稱
-
-        Returns:
-            str: 輸出的histroy plot label
-        """
-        pat = re.compile(r'dataset_1_(aug_[0-9]*)')
-        return pat.findall(exp_name)[0]
-
-    main(extract_lbl_keyword_func)
+    pattern_to_extract_label = re.compile(r'dataset_1_(aug_[0-9]+)')
+    main(pattern_to_extract_label)

--- a/o.py
+++ b/o.py
@@ -1,6 +1,6 @@
 import os
 import pickle
-from typing import Tuple
+from typing import Tuple, Callable
 import matplotlib.pyplot as plt
 from matplotlib.axes._subplots import Axes
 import re
@@ -86,7 +86,7 @@ def plot_history(history: dict,
     return ax1, ax2
 
 
-def main():
+def main(extract_lbl_keyword_func: Callable):
     display_exp = sorted(os.listdir('experiments'))
     exp_s = "\n".join(display_exp)
     print(f'all experiments are : {exp_s}')
@@ -118,8 +118,7 @@ def main():
                     row = 2
                 else:
                     raise ValueError('should be 3 fold in this experiments')
-                pat = re.compile(r'dataset_1_(aug_[0-9]*)')
-                short_exp_name = pat.findall(exp_name)[0]
+                short_exp_name = extract_lbl_keyword_func(exp_name)
                 axes[row][0], axes[row][1] = plot_history(history=history,
                                                           ax1=axes[row][0], ax2=axes[row][1],
                                                           lbl=short_exp_name,
@@ -137,4 +136,17 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    def extract_lbl_keyword_func(exp_name: str) -> str:
+        """
+        擷取實驗名稱，放在畫圖的legend上
+
+        Args:
+            exp_name (str): 輸入的實驗名稱
+
+        Returns:
+            str: 輸出的histroy plot label
+        """
+        pat = re.compile(r'dataset_1_(aug_[0-9]*)')
+        return pat.findall(exp_name)[0]
+
+    main(extract_lbl_keyword_func)

--- a/s.py
+++ b/s.py
@@ -2,6 +2,14 @@
 特徵與目標的相關性分析，以house_price為例
 將各個特徵與目標的相關係數畫出，排序後，並以bar plot表示
 希望以後可以重複利用這些函數
+
+-----------------------------------
+SRP 單一職責原則，將plot_feature_corr_sorting這隻函數拆小
+並以時常更動地方進行拆分
+1. 要計算相關係數的特徵欄位可能會經常過濾 - filter_col
+2. 畫圖可能會經常修改畫圖參數，例如xy座標，標題等 - plot_barh
+plot_feature_corr_sorting 修改為calculate_correlation
+
 '''
 
 import pandas as pd
@@ -39,31 +47,71 @@ def colormap2rgb(num_colors: int,
     return rgba_color, rgb_color
 
 
-# +
-def plot_feature_corr_sorting(df: pd.DataFrame, target: str,
-                              verbose: bool = False,
-                              fig_title: str = 'Correlations with Target') -> None:
+def filter_col(df: pd.DataFrame, dtype: str = 'number') -> pd.DataFrame:
     """
-    輸入dataframe，畫出對各個數值特徵對目標的相關係數
+    從整個dataframe中過濾出特定欄位
+    本函數會選出欄位資料型態不是object的欄位
+
+    Args : 
+        df (pd.DataFrame): 整個需要分析的dataframe
+    Returns : 
+        df (pd.DataFrame): 經過過濾的dataframe
+    """
+    if dtype == 'number':
+        cols = [var for var in df.columns if df[var].dtypes != 'O']
+    else:
+        raise NotImplementedError(f'尚未實作該過濾機制，你目前輸入的dype為 {dtype}')
+    return df[cols]
+
+
+def plot_barh(df: pd.DataFrame,
+              y='corr_with_targets',
+              x='features',
+              fig_title='Correlations with Target') -> None:
+    """
+    畫出Barh
 
     Args:
-        df (pd.DataFrame): 整個需要分析的dataframe
-        target (str): 目標變數
-        verbose(bool) : 是否需要顯示各個變數對目標變數的相關係數 Default to False
+        df (pd.DataFrame): 要畫的圖
+        y (str): y軸座標字串
+        x (str): x軸座標字串
         fig_title(str) : 畫圖標題
 
     Returns:
         None
 
     """
+    rgba_list, _ = colormap2rgb(num_colors=df.shape[0])
+    with plt.style.context(['science', 'grid', 'no-latex']):
+        fig, ax = plt.subplots(figsize=(3, 4), dpi=200)
+        ax.barh(df[x], df[y], color=rgba_list)
+        plt.xlabel(y)
+        plt.title(fig_title)
+        plt.tight_layout()
+        plt.show()
+
+
+def caculate_correlation(df: pd.DataFrame, target: str,
+                         verbose: bool = False) -> pd.DataFrame:
+    """
+    給定一個dataframe，計算所有欄位對於目標變數的相關係數
+
+    Args:
+        df (pd.DataFrame): 需要計算相關係數的dataframe
+        target (str): 目標變數
+        verbose(bool) : 是否需要顯示各個變數對目標變數的相關係數 Default to False
+
+    Returns:
+        df (pd.DataFrame): 計算完成的dataframe，內含兩個欄位 : 'features', 'corr_with_targets'
+
+    """
     import operator
 
     individual_features_df = []
-    num_cols = [var for var in df.columns if df[var].dtypes != 'O']
-    df_num = df[num_cols]
-    for i in range(0, len(df_num.columns) - 1):
-        tmp_df = df_num[[df_num.columns[i], target]]
-        tmp_df = tmp_df[tmp_df[df_num.columns[i]] != 0]
+    n_features = len(df.columns) - 1
+    for i in range(0, n_features):
+        tmp_df = df[[df.columns[i], target]]
+        tmp_df = tmp_df[tmp_df[df.columns[i]] != 0]
         individual_features_df.append(tmp_df)
 
     all_correlations = {feature.columns[0]: feature.corr(
@@ -73,24 +121,15 @@ def plot_feature_corr_sorting(df: pd.DataFrame, target: str,
     if verbose:
         for (key, value) in all_correlations:
             print("{:>15}: {:>15}".format(key, value))
-    df_corr = pd.DataFrame(all_correlations, columns=[
-                           'features', 'corr_with_targets'])
 
-    rgba_list, _ = colormap2rgb(num_colors=df_corr.shape[0])
-    with plt.style.context(['science', 'grid', 'no-latex']):
-        fig, ax = plt.subplots(figsize=(3, 4), dpi=200)
-        ax.barh(df_corr['features'],
-                df_corr['corr_with_targets'],
-                color=rgba_list)
-        plt.xlabel('features')
-        plt.title(fig_title)
-        plt.tight_layout()
-        plt.show()
+    return pd.DataFrame(all_correlations, columns=['features', 'corr_with_targets'])
 
 
 def main():
     df = pd.read_csv('data/house_price.csv')
-    plot_feature_corr_sorting(df=df, target='SalePrice')
+    df_num = filter_col(df)
+    df_corr = caculate_correlation(df_num, target='SalePrice')
+    plot_barh(df_corr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
before

```
class User:
     ...
    def deactivate(self):
        """
        停用該使用者
        """
        self.is_active = False


def deactivate_users(users: Iterable[User]):
    """
    批量停用使用者
    """
    for user in users:
        # 無法停用管理員，跳過
        if isinstance(user, Admin):
            print(f'skip deactivating admin user {user.username}')
            continue
        else:
            user.deactivate()

```


after 

```
class User():
    """
    普通使用者
    """
     ....
    def allow_deactivate(self) -> bool:
        """
        是否允許停用
        """
        return True

    def deactivate(self):
        """
        停用該使用者
        """
        self.is_active = False



def deactivate_users(users: Iterable[User]):
    """
    批量停用使用者
    """
    for user in users:
        # 該使用者無法被停用
        if not user.allow_deactivate():
            print(
                f'''skip deactivating user {user.username}\n because it is {user.__class__.__name__}''')
            continue
        else:
            user.deactivate
```

若之後有擴充新的子類別，例如stuff, vip等，`deactivate_users`這個函數不會壞掉，而且也不夠改，將來更好為維護
